### PR TITLE
HOTFIX/ATL-2674 - Fixes syntax that isn't valid in PHP 8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,15 @@
 {
-    "name": "raveren/kint",
-    "description": "Kint - debugging helper for PHP developers",
+    "name": "i6systems/kint",
+    "description": "A fork of an old version of kint-php/kint",
     "keywords": ["kint", "php", "debug"],
     "type": "library",
-    "homepage": "https://github.com/raveren/kint",
+    "homepage": "https://github.com/i6systems/kint",
     "license": "MIT",
     "authors": [
+        {
+            "name": "i6 Systems",
+            "homepage": "https://github.com/i6systems"
+        },
         {
             "name": "Rokas Šleinius",
             "homepage": "https://github.com/raveren"

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,11 @@
 {
-    "name": "i6systems/kint",
-    "description": "A fork of an old version of kint-php/kint",
+    "name": "raveren/kint",
+    "description": "Kint - debugging helper for PHP developers",
     "keywords": ["kint", "php", "debug"],
     "type": "library",
-    "homepage": "https://github.com/i6systems/kint",
+    "homepage": "https://github.com/raveren/kint",
     "license": "MIT",
     "authors": [
-        {
-            "name": "i6 Systems",
-            "homepage": "https://github.com/i6systems"
-        },
         {
             "name": "Rokas Šleinius",
             "homepage": "https://github.com/raveren"

--- a/parsers/custom/color.php
+++ b/parsers/custom/color.php
@@ -82,16 +82,16 @@ class Kint_Parsers_Color extends kintParser
 			$color            = self::$_css3Named[$color];
 		}
 
-		if ( $color{0} === '#' ) {
+		if ( $color[0] === '#' ) {
 			$variants['hex'] = $color;
 			$color           = substr( $color, 1 );
 			if ( strlen( $color ) === 6 ) {
 				$colors = str_split( $color, 2 );
 			} else {
 				$colors = array(
-					$color{0} . $color{0},
-					$color{1} . $color{1},
-					$color{2} . $color{2},
+					$color[0] . $color[0],
+					$color[1] . $color[1],
+					$color[2] . $color[2],
 				);
 			}
 

--- a/parsers/custom/json.php
+++ b/parsers/custom/json.php
@@ -4,7 +4,7 @@ class Kint_Parsers_Json extends kintParser
 	protected function _parse( & $variable )
 	{
 		if ( !is_string( $variable )
-			|| !isset( $variable{0} ) || ( $variable{0} !== '{' && $variable{0} !== '[' )
+			|| !isset( $variable[0] ) || ( $variable[0] !== '{' && $variable[0] !== '[' )
 			|| ( $json = json_decode( $variable ) ) === null
 		) return false;
 


### PR DESCRIPTION
Replaces use of `array{$key}` with the standard `array[0]`